### PR TITLE
Melhorando a sintaxe

### DIFF
--- a/pygments_portugol/__init__.py
+++ b/pygments_portugol/__init__.py
@@ -6,7 +6,7 @@
     Pygments lexer for Portugol Studio, a algorithmic language for beginners in Portuguese.
 
     :copyright: Copyright 2021 Héliton Martins
-    :license: GPL v2.0, see LICENSE for details.
+    :license: GPL v3.0, see LICENSE for details.
 """
 
 import re
@@ -36,14 +36,6 @@ class PortugolStudioLexer(RegexLexer):
 
     tokens = {
         'whitespace': [
-            # preprocessor directives: without whitespace
-            # (r'^#if\s+0', Comment.Preproc, 'if0'),
-            # ('^#', Comment.Preproc, 'macro'),
-            # # or with whitespace
-            # ('^(' + _ws1 + r')(#if\s+0)',
-            #  bygroups(using(this), Comment.Preproc), 'if0'),
-            # ('^(' + _ws1 + ')(#)',
-            #  bygroups(using(this), Comment.Preproc), 'macro'),
             (r'\n', Text),
             (r'\s+', Text),
             (r'\\\n', Text),  # line continuation
@@ -53,17 +45,15 @@ class PortugolStudioLexer(RegexLexer):
             (r'/(\\\n)?[*][\w\W]*', Comment.Multiline),
         ],
         'statements': [
-            (r'(L?)(")', bygroups(String.Affix, String), 'string'),
-            (r"(L?)(')(\\.|\\[0-7]{1,3}|\\x[a-fA-F0-9]{1,2}|[^\\\'\n])(')",
-             bygroups(String.Affix, String.Char, String.Char, String.Char)),
-            (r'(\d+\.\d*|\.\d+|\d+)[eE][+-]?\d+[LlUu]*', Number.Float),
-            (r'(\d+\.\d*|\.\d+|\d+[fF])[fF]?', Number.Float),
-            (r'0x[0-9a-fA-F]+[LlUu]*', Number.Hex),
-            (r'0[0-7]+[LlUu]*', Number.Oct),
-            (r'\d+[LlUu]*', Number.Integer),
+            (r'(")', bygroups(String), 'string'),
+            (r"(')(\\.|\\[0-7]{1,3}|\\x[a-fA-F0-9]{1,2}|[^\\\'\n])(')",
+             bygroups(String.Char, String.Char, String.Char)),
+            (r'0x[0-9a-fA-F]+', Number.Hex),
+            (r'\d+', Number.Integer),
             (r'\*/', Error),
-            (r'[~!%^&*+=|?:<>/-]', Operator),
-            (r'[()\[\],.]', Punctuation),
+            (r'(?:!)', Error),
+            (r'[~%&*+=|?<>/-]', Operator),
+            (r'[()\[\],:.]', Punctuation),
             (words(('pare', 'caso', 'const', 'continue',
                     'faca', 'senao', 'para',
                     'se', 'retorne',
@@ -73,18 +63,9 @@ class PortugolStudioLexer(RegexLexer):
              Keyword.Type),
             (words(('inclua', 'biblioteca', 'funcao', 'programa'),
                    suffix=r'\b'), Keyword.Reserved),
-            # Vector intrinsics
-            # (r'(__m(128i|128d|128|64))\b', Keyword.Reserved),
-            # Microsoft-isms
-            # (words((
-            #     'asm', 'int8', 'based', 'except', 'int16', 'stdcall', 'cdecl',
-            #     'fastcall', 'int32', 'declspec', 'finally', 'int64', 'try',
-            #     'leave', 'wchar_t', 'w64', 'unaligned', 'raise', 'noop',
-            #     'identifier', 'forceinline', 'assume'),
-            #     prefix=r'__', suffix=r'\b'), Keyword.Reserved),
             (r'(verdadeiro|falso|ou|e|nao)\b', Name.Builtin),
             (r'([a-zA-Z_]\w*)(\s*)(:)(?!:)',
-             bygroups(Name.Label, Text, Punctuation)),
+             bygroups(Name.Label, Text, Punctuation)),  # switch-case statements
             (r'[a-zA-Z_]\w*', Name),
         ],
         'root': [
@@ -101,7 +82,7 @@ class PortugolStudioLexer(RegexLexer):
             include('whitespace'),
             include('statements'),
             ('[{}]', Punctuation),
-            (';', Punctuation, '#pop'),
+            (';', Error),
         ],
         'funcao': [
             include('whitespace'),
@@ -115,35 +96,9 @@ class PortugolStudioLexer(RegexLexer):
             (r'\\([\\abfnrtv"\']|x[a-fA-F0-9]{2,4}|'
              r'u[a-fA-F0-9]{4}|U[a-fA-F0-9]{8}|[0-7]{1,3})', String.Escape),
             (r'[^\\"\n]+', String),  # all other characters
-            (r'\\\n', String),  # line continuation
             (r'\\', String),  # stray backslash
-        ],
-        'macro': [
-            (r'(inclua|biblioteca)(' + _ws1 + r')([^\n]+)',
-             bygroups(Comment.Preproc, Text, Comment.PreprocFile)),
-            (r'[^/\n]+', Comment.Preproc),
-            (r'/[*](.|\n)*?[*]/', Comment.Multiline),
-            (r'//.*?\n', Comment.Single, '#pop'),
-            (r'/', Comment.Preproc),
-            (r'(?<=\\)\n', Comment.Preproc),
-            (r'\n', Comment.Preproc, '#pop'),
         ],
     }
 
-    stdlib_types = set((
-        'size_t', 'ssize_t', 'off_t', 'wchar_t', 'ptrdiff_t', 'sig_atomic_t', 'fpos_t',
-        'clock_t', 'time_t', 'va_list', 'jmp_buf', 'FILE', 'DIR', 'div_t', 'ldiv_t',
-        'mbstate_t', 'wctrans_t', 'wint_t', 'wctype_t'))
-
     def __init__(self, **options):
-        self.stdlibhighlighting = get_bool_opt(
-            options, 'stdlibhighlighting', True)
         RegexLexer.__init__(self, **options)
-
-    def get_tokens_unprocessed(self, text):
-        for index, token, value in \
-                RegexLexer.get_tokens_unprocessed(self, text):
-            if token is Name:
-                if self.stdlibhighlighting and value in self.stdlib_types:
-                    token = Keyword.Type
-            yield index, token, value

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='pygments_portugol',
-    version='0.1.0',
+    version='0.2.0',
     description='Pygments lexer for Portugol Studio.',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Removi várias regras que não são aceitas pelo Portugol Studio. 
- Números hexadecimais podem ser escritos com a notação usual `0xff`;
- Removida a notação para números octais;
- Removida a notação científica, como `3e-4` (que seria interpretado como `0.0003` em várias linguagens);
- Pontos-e-vírgulas são marcados como erro;
- Exclamações são marcadas como erro.
- Outras mudanças minoritárias.